### PR TITLE
Adding quiet mode to skip showing notification when the theme switches.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Nightlight can be configured by setting the following settings:
 * `nightlight.dayTimeEnd`: The time (format HH:mm) at which day time ends (if no GPS coordinates are configured) 
 * `nightlight.gpsLong`: The GPS longitude coordinate. This is used to determine the sunrise and sunset locally on your device.
 * `nightlight.gpsLat`: The GPS latitude coordinate. This is used to determine the sunrise and sunset locally on your device.
+* `nightlight.quiet`: Switch theme quietly (don't show notification).
 
 ## Release Notes
 

--- a/package.json
+++ b/package.json
@@ -85,6 +85,11 @@
                     "default": null,
                     "description": "The GPS latitude coordinate. This is used to determine the sunrise and sunset locally on your device."
                 },
+                "nightlight.quiet": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Switch theme quietly (don't show notification)"
+                },
                 "nightlight.overrideUntil": {
                     "type": "date",
                     "default": null,

--- a/src/nightlight-config.ts
+++ b/src/nightlight-config.ts
@@ -11,6 +11,7 @@ export class NightlightConfig {
   public dayTimeEnd: Date = new Date("1970-01-01 21:00");
   public gpsLong: number | null = null;
   public gpsLat: number | null = null;
+  public quiet: boolean = false;
   public overrideUntil: Date | null = null;
 
   public static load() {
@@ -25,6 +26,7 @@ export class NightlightConfig {
     config.dayTimeEnd = configDayTimeEnd !== null ? configDayTimeEnd : config.dayTimeEnd;
     config.gpsLong = vscode.workspace.getConfiguration('nightlight').get('gpsLong') || config.gpsLong;
     config.gpsLat = vscode.workspace.getConfiguration('nightlight').get('gpsLat') || config.gpsLat;
+    config.quiet = vscode.workspace.getConfiguration('nightlight').get('quiet') || config.quiet;
     config.overrideUntil = new Date(vscode.workspace.getConfiguration('nightlight').get('overrideUntil') as string) || config.overrideUntil;
     return config;
   }

--- a/src/nightlight.ts
+++ b/src/nightlight.ts
@@ -45,13 +45,17 @@ export class Nightlight {
 
     if (this.isDayTime()) {
       if (currentTheme !== this.config.dayTheme && !this.isOverrideSet()) {
-        vscode.window.showInformationMessage("Hello! I'll turn on the lights for you.");
+        if (!this.config.quiet) {
+          vscode.window.showInformationMessage("Hello! I'll turn on the lights for you.");
+        }
         this.enableDayTheme();
       }
     }
     else {
       if (currentTheme !== this.config.nightTheme && !this.isOverrideSet()) {
-        vscode.window.showInformationMessage("It's getting dark, I'm switching off the lights.");
+        if (!this.config.quiet) {
+          vscode.window.showInformationMessage("It's getting dark, I'm switching off the lights.");
+        }
         this.enableNightTheme();
       }
     }


### PR DESCRIPTION
Thank you for the extension, @intodevelopment.

I've modified it to skip printing the notification that the theme changed. If you like it, feel free to add it to your project!

Best regards!