### PR TITLE
Make timer's type more general

### DIFF
--- a/src/nightlight.ts
+++ b/src/nightlight.ts
@@ -5,7 +5,7 @@ var suncalc = require('suncalc');
 
 export class Nightlight {
 
-  private _timer: null | NodeJS.Timer = null;
+  private _timer: null | ReturnType<typeof setInterval> = null;
 
   constructor(private config: NightlightConfig) {
     if(!this.validateGpsCoordinates()){


### PR DESCRIPTION
Nightlight doesn't run only on Node context anymore, it can also work as a web extension. So the type was not exactly correct and comprehensive.